### PR TITLE
Update regexpp and add support for ES2025 duplicate named capturing groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.8.0",
+        "@eslint-community/regexpp": "^4.11.0",
         "refa": "^0.12.1"
       },
       "devDependencies": {
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
-      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -6471,9 +6471,9 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
-      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg=="
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A=="
     },
     "@eslint/eslintrc": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "5.0"
   },
   "dependencies": {
-    "@eslint-community/regexpp": "^4.8.0",
+    "@eslint-community/regexpp": "^4.11.0",
     "refa": "^0.12.1"
   },
   "files": [

--- a/src/consumed-chars.ts
+++ b/src/consumed-chars.ts
@@ -1,7 +1,7 @@
 import { Alternative, Element, Pattern } from "@eslint-community/regexpp/ast";
 import { CharSet } from "refa";
 import { ReadonlyFlags } from "./flags";
-import { hasSomeDescendant, isEmptyBackreference } from "./basic";
+import { getReferencedGroupsFromBackreference, hasSomeDescendant, isEmptyBackreference } from "./basic";
 import { Chars } from "./chars";
 import { toUnicodeSet } from "./to-char-set";
 
@@ -49,9 +49,11 @@ export function getConsumedChars(element: Element | Pattern | Alternative, flags
 
 				exact = exact && !c.isEmpty;
 			} else if (d.type === "Backreference" && !isEmptyBackreference(d, flags)) {
-				const c = getConsumedChars(d.resolved, flags);
-				sets.push(c.chars);
-				exact = exact && c.exact && c.chars.size < 2;
+				for (const resolved of getReferencedGroupsFromBackreference(d)) {
+					const c = getConsumedChars(resolved, flags);
+					sets.push(c.chars);
+					exact = exact && c.exact && c.chars.size < 2;
+				}
 			}
 
 			// always continue to the next element

--- a/src/follow.ts
+++ b/src/follow.ts
@@ -339,7 +339,6 @@ export function followPaths<S>(
 			parent.type === "CharacterClassRange" ||
 			parent.type === "ClassIntersection" ||
 			parent.type === "ClassSubtraction" ||
-			parent.type === "ExpressionCharacterClass" ||
 			parent.type === "StringAlternative"
 		) {
 			throw new Error("The given element cannot be part of a character class.");

--- a/tests/__snapshots__/consumed-chars.ts.snap
+++ b/tests/__snapshots__/consumed-chars.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getConsumedChars /(?:(?<foo>a)|(?<foo>b))\\k<foo>/ 1`] = `
+Object {
+  "chars": CharSet (65535) [61..62],
+  "exact": true,
+}
+`;
+
+exports[`getConsumedChars /(?:(?<foo>abc)|(?<foo>x))\\k<foo>/ 1`] = `
+Object {
+  "chars": CharSet (65535) [61..63, 78],
+  "exact": false,
+}
+`;
+
 exports[`getConsumedChars /(?:\\d*\\.\\d+|\\d+\\.\\d*)_/ 1`] = `
 Object {
   "chars": CharSet (65535) [2e, 30..39, 5f],

--- a/tests/__snapshots__/next-char.ts.snap
+++ b/tests/__snapshots__/next-char.ts.snap
@@ -147,6 +147,14 @@ Object {
 }
 `;
 
+exports[`getFirstConsumedChar /(?:(?<foo>a)|(?<foo>b))\\k<foo>/ (ltr) 1`] = `
+Object {
+  "char": CharSet (65535) [61..62],
+  "empty": false,
+  "exact": true,
+}
+`;
+
 exports[`getFirstConsumedChar /(?:(a)|b)\\1/ (rtl) 1`] = `
 Object {
   "char": CharSet (65535) [61..62],

--- a/tests/__snapshots__/reorder.ts.snap
+++ b/tests/__snapshots__/reorder.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`canReorder /(?:(?<foo>a)|(?<foo>b))\\k<foo>/ 1`] = `
+Object {
+  "(?:(?<foo>a)|(?<foo>b))": Object {
+    "(?<foo>a)|(?<foo>b)": Object {
+      "dir:ltr     ignoreCG:false": false,
+      "dir:ltr     ignoreCG:true ": true,
+      "dir:rtl     ignoreCG:false": false,
+      "dir:rtl     ignoreCG:true ": true,
+      "dir:unknown ignoreCG:false": false,
+      "dir:unknown ignoreCG:true ": true,
+    },
+  },
+}
+`;
+
+exports[`canReorder /(?:(?<foo>abc)|(?<foo>x))\\k<foo>/ 1`] = `
+Object {
+  "(?:(?<foo>abc)|(?<foo>x))": Object {
+    "(?<foo>abc)|(?<foo>x)": Object {
+      "dir:ltr     ignoreCG:false": false,
+      "dir:ltr     ignoreCG:true ": true,
+      "dir:rtl     ignoreCG:false": false,
+      "dir:rtl     ignoreCG:true ": true,
+      "dir:unknown ignoreCG:false": false,
+      "dir:unknown ignoreCG:true ": true,
+    },
+  },
+}
+`;
+
 exports[`canReorder /(?:\\d*\\.\\d+|\\d+\\.\\d*)_/ 1`] = `
 Object {
   "(?:\\\\d*\\\\.\\\\d+|\\\\d+\\\\.\\\\d*)": Object {

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -268,3 +268,33 @@ describe("hasSomeAncestor and hasSomeDescendant condition", function () {
 		return nodes;
 	}
 });
+
+describe(RAA.getReferencedGroupsFromBackreference.name, function () {
+	interface TestCase {
+		regexp: RegExp | string;
+		expected?: string[];
+	}
+
+	test([
+		{ regexp: /(a)\1/, expected: ["(a)"] },
+		{ regexp: /(a)(?:\1)/, expected: ["(a)"] },
+		{ regexp: /(a)|\1/, expected: [] },
+		{ regexp: /(a\1)/, expected: [] },
+		{ regexp: String.raw`/(?:(?<foo>a)|(?<foo>b))\k<foo>/`, expected: ["(?<foo>a)", "(?<foo>b)"] },
+		{ regexp: String.raw`/(?:(?<foo>a)|(?<foo>b)\k<foo>)/`, expected: ["(?<foo>b)"] },
+	]);
+
+	function test(cases: TestCase[]): void {
+		for (const { regexp, expected } of cases) {
+			it(`${regexp}`, function () {
+				const { pattern } = new RegExpParser().parseLiteral(regexp.toString());
+				const [ref] = select(pattern, (e): e is Backreference => e.type === "Backreference");
+				const actual = RAA.getReferencedGroupsFromBackreference(ref);
+				assert.deepEqual(
+					actual.map(a => a.raw),
+					expected
+				);
+			});
+		}
+	}
+});

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -6,7 +6,7 @@ import * as RAA from "../src";
 import { assert } from "chai";
 
 describe(RAA.isStrictBackreference.name, function () {
-	function test(expected: boolean, regexps: RegExp[]): void {
+	function test(expected: boolean, regexps: (RegExp | string)[]): void {
 		describe(`${expected}`, function () {
 			regexps
 				.map(r => new RegExpParser().parseLiteral(r.toString()))
@@ -21,7 +21,16 @@ describe(RAA.isStrictBackreference.name, function () {
 		});
 	}
 
-	test(true, [/(a)\1/, /(a)(?:b|\1)/, /(a)\1?/, /(?<=\1(a))b/, /(?!(a)\1)/]);
+	test(true, [
+		/(a)\1/,
+		/(a)(?:b|\1)/,
+		/(a)\1?/,
+		/(?<=\1(a))b/,
+		/(?!(a)\1)/,
+		/(?:(?<foo>a))\k<foo>/,
+		String.raw`/(?:(?<foo>a)|(?<foo>b))\k<foo>/`,
+		String.raw`/(?:(?<foo>a)|(?<foo>b)\k<foo>)/`,
+	]);
 	test(false, [
 		/(a)|\1/,
 		/(a\1)/,
@@ -31,11 +40,13 @@ describe(RAA.isStrictBackreference.name, function () {
 		/(?=\1(a))/,
 		/(?!(a))\w\1/,
 		/(?!(?!(a)))\w\1/,
+		String.raw`/(?:(?<foo>a)||(?<foo>b))\k<foo>/`,
+		String.raw`/(?:(?<foo>a)?|(?<foo>b))\k<foo>/`,
 	]);
 });
 
 describe(RAA.isEmptyBackreference.name, function () {
-	function test(expected: boolean, regexps: RegExp[]): void {
+	function test(expected: boolean, regexps: (RegExp | string)[]): void {
 		describe(`${expected}`, function () {
 			regexps
 				.map(r => new RegExpParser().parseLiteral(r.toString()))
@@ -60,8 +71,21 @@ describe(RAA.isEmptyBackreference.name, function () {
 		/(?!(a))\w\1/,
 		/(?!(?!(a)))\w\1/,
 		/(\3)(\1)(\2)/,
+		/(?:(?<foo>))\k<foo>/,
+		String.raw`/(?:(?<foo>)|(?<foo>))\k<foo>/`,
+		String.raw`/(?:(?<foo>)\k<foo>|(?<foo>b))/`,
 	]);
-	test(false, [/(?:(a)|b)\1/, /(a)?\1/, /(a)\1/, /(?=(a))\w\1/, /(?!(a)\1)/]);
+	test(false, [
+		/(?:(a)|b)\1/,
+		/(a)?\1/,
+		/(a)\1/,
+		/(?=(a))\w\1/,
+		/(?!(a)\1)/,
+		/(?:(?<foo>a))\k<foo>/,
+		String.raw`/(?:(?<foo>a)|(?<foo>))\k<foo>/`,
+		String.raw`/(?:(?<foo>)|(?<foo>b))\k<foo>/`,
+		String.raw`/(?:(?<foo>)|(?<foo>b)\k<foo>)/`,
+	]);
 });
 
 describe(RAA.getCapturingGroupNumber.name, function () {

--- a/tests/equal.ts
+++ b/tests/equal.ts
@@ -4,8 +4,8 @@ import { assert } from "chai";
 
 describe(RAA.structurallyEqual.name, function () {
 	interface TestCase {
-		a: RegExp;
-		b: RegExp;
+		a: RegExp | string;
+		b: RegExp | string;
 		expected?: boolean;
 	}
 
@@ -47,6 +47,32 @@ describe(RAA.structurallyEqual.name, function () {
 		{ a: /(?=a)/, b: /(?=a)/ },
 		{ a: /(?=a)/, b: /(?!a)/, expected: false },
 		{ a: /(?=a)/, b: /(?<=a)/, expected: false },
+
+		{
+			a: String.raw`/(?:(?<foo>a)|(?<foo>b))\k<foo>/`,
+			b: String.raw`/(?:(?<bar>a)|(?<bar>b))\k<bar>/`,
+			expected: true,
+		},
+		{
+			a: String.raw`/(?:(?<foo>a)|(?<foo>b))\k<foo>/`,
+			b: String.raw`/(?:(?<foo>b)|(?<foo>a))\k<foo>/`,
+			expected: false,
+		},
+		{
+			a: String.raw`/(?:(?<foo>a)|(?<foo>b))\k<foo>/`,
+			b: String.raw`/(?:(?<foo>a)|(?<foo>b))\1/`,
+			expected: false,
+		},
+		{
+			a: String.raw`/(?:(?<foo>a)|(?<foo>a))\k<foo>/`,
+			b: String.raw`/(?:(?<foo>a)|(a))\1/`,
+			expected: false,
+		},
+		{
+			a: String.raw`/(?:(?<foo>a)|(?<foo>a))\k<foo>/`,
+			b: String.raw`/(?:(?<foo>a)|(?<foo>a))\1/`,
+			expected: false,
+		},
 	]);
 
 	function test(cases: TestCase[]): void {

--- a/tests/helper/data.ts
+++ b/tests/helper/data.ts
@@ -51,4 +51,6 @@ export const TEST_REGEXES: readonly (RegExp | string)[] = [
 	String.raw`/foo|[\q{bar}]/v`,
 	String.raw`/abc|\p{Basic_Emoji}/v`,
 	/(abc)(?:foo|bar|\1)/,
+	String.raw`/(?:(?<foo>a)|(?<foo>b))\k<foo>/`,
+	String.raw`/(?:(?<foo>abc)|(?<foo>x))\k<foo>/`,
 ];

--- a/tests/length.ts
+++ b/tests/length.ts
@@ -298,6 +298,9 @@ describe(RAA.getLengthRange.name, function () {
 		{ regexp: /(?:(a)|b)\1/, expected: { min: 1, max: 2 } },
 		{ regexp: /(a*)(?<backref>\1)/, expected: { min: 0, max: Infinity }, selectNamed: true },
 
+		{ regexp: String.raw`/(?:(?<foo>x)|(?<foo>abc))\k<foo>/`, expected: { min: 2, max: 6 } },
+		{ regexp: String.raw`/(?:(?<foo>x)|(?<foo>abc)\k<foo>)/`, expected: { min: 1, max: 6 } },
+
 		// Limitations:
 		// "All characters classes/sets are assumed to consume at least one characters and all assertions are assumed
 		// to have some accepting path."

--- a/tests/next-char.ts
+++ b/tests/next-char.ts
@@ -17,7 +17,7 @@ function* iter<T>(array: T | T[]): IterableIterator<T> {
 
 describe(RAA.getFirstConsumedChar.name, function () {
 	interface TestCase {
-		regexp: RegExp | RegExp[];
+		regexp: RegExp | RegExp[] | string;
 		direction?: MatchingDirection;
 	}
 
@@ -44,6 +44,8 @@ describe(RAA.getFirstConsumedChar.name, function () {
 		{ regexp: /(a)b\1/ },
 		{ regexp: /\1(a)/ },
 		{ regexp: /\1a|a(b)/ },
+
+		{ regexp: String.raw`/(?:(?<foo>a)|(?<foo>b))\k<foo>/` },
 
 		// assertions
 


### PR DESCRIPTION
This PR updates regexpp and add support for ES2025 duplicate named capturing groups.

See also https://github.com/ota-meshi/eslint-plugin-regexp/pull/752, and https://github.com/eslint-community/regexpp/pull/195